### PR TITLE
Letters are flickering repeatedly on typing very fast on (CKEditor + Codemirror) plugin source editor

### DIFF
--- a/lib/CKEditor.js
+++ b/lib/CKEditor.js
@@ -87,6 +87,7 @@ var CKEditor = exports.CKEditor = (_dec = (0, _core.Component)({
         _initDefineProp(this, 'host', _descriptor5, this);
 
         this.value = '';
+	this.updateModelWithDelay = '';
         this.instance = this.instance;
         this.ngControl = this.ngControl;
         this.renderer = this.renderer;
@@ -150,7 +151,12 @@ var CKEditor = exports.CKEditor = (_dec = (0, _core.Component)({
         value: function onValueChange(event) {
             var value = this.host.nativeElement.value;
             this.change.emit(value);
-            if (this.ngControl) this.ngControl.viewToModelUpdate(value);
+            var self = this;
+            clearTimeout(this.updateModelWithDelay);
+            this.updateModelWithDelay = setTimeout(function () {
+                if (self.ngControl)
+                    self.ngControl.viewToModelUpdate(value);
+            }, 200);
         }
 
         /**


### PR DESCRIPTION
**Issue:** When we start typing very fastly on CKEditor source section with codemirror (syntex highlighting) plugin, the cursor unexpectedly goes up the top (starting point) of editor and seems the letters are flickering repeatedly like change events goes into a loop.

**Cause:** "textarea"  element **OnChange** or Key events used by codemirror and our CKEditor.js both. So when anything typed very fast, these simultaneously events results into a loop and start repeating.

**Fix:**  Added a little delay to update model data from view to ensure that events won't executes same time.

Thanks,
Anuj