### PR TITLE
Update CKeditor value on instance ready

### DIFF
--- a/src/ckeditor.component.ts
+++ b/src/ckeditor.component.ts
@@ -144,6 +144,12 @@ export class CKEditorComponent implements OnChanges, AfterViewInit {
 
       // listen for instanceReady event
       this.instance.on('instanceReady', (evt: any) => {
+        // if value has changed while instance loading
+        // update instance with current component value
+        if (this.instance.getData() !== this.value) {
+          this.instance.setData(this.value);
+        }
+
         // send the evt to the EventEmitter
         this.ready.emit(evt);
       });


### PR DESCRIPTION
Handle situation when component value was changed after CKeditor inited and before it ready.
This happens time to time, depending on timings. And in that case component property "_value" is not in sync with actual text inside CKeditor. So as solution i suggest to check actualy CKeditor value after instance ready, and if it doesnt match component "_value" property, update it