### PR TITLE
Angular 8 support

### DIFF
--- a/src/ckeditor.component.ts
+++ b/src/ckeditor.component.ts
@@ -53,7 +53,7 @@ export class CKEditorComponent implements OnChanges, AfterViewInit {
   @Output() paste = new EventEmitter();
   @Output() drop = new EventEmitter();
 
-  @ViewChild('host') host: any;
+  @ViewChild('host', {static:false}) host: any;
 
   @ContentChildren(CKButtonDirective) toolbarButtons: QueryList<CKButtonDirective>;
   @ContentChildren(CKGroupDirective) toolbarGroups: QueryList<CKGroupDirective>;


### PR DESCRIPTION
ViewChild update in order to support the new Angular 8 way of querying templates.
https://angular.io/guide/static-query-migration