### PR TITLE
Remove call to CKEDITOR.removeAllListeners()

### DIFF
--- a/src/ckeditor.component.ts
+++ b/src/ckeditor.component.ts
@@ -91,7 +91,6 @@ export class CKEditorComponent implements OnChanges, AfterViewInit, OnDestroy {
     this.destroyed = true;
     this.zone.runOutsideAngular(() => {
       if (this.instance) {
-        CKEDITOR.removeAllListeners();
         this.instance.destroy();
         this.instance = null;
       }


### PR DESCRIPTION
Hello,

I believe we found a bug in this library a while back that was introduced in 5ada62c80a40ae9311219ce07574c4fb89c2a302

We have a custom ckeditor plugin that replaces references like `${thisOne}` with a fancy looking 'placeholder' you can click on to open a model.  Pressing backspace deletes the entire placeholder at once.  

After upgrading this library we noticed you could no longer delete the placeholder, and the cursor would jump to the bottom when pressing backspace:

![aa](https://user-images.githubusercontent.com/91095756/197586990-5fe34b0f-d338-4cf3-b750-dc2d816233d5.gif)

As well as console errors:
<img width="1032" alt="aaa" src="https://user-images.githubusercontent.com/91095756/197587052-b3b30a4b-f954-4e18-9740-76f6b983a54d.png">

I tracked it down to the call to `CKEDITOR.removeAllListeners()`.  What I believe was happening was that if a ckeditor instance got destroyed on the page, it would remove all listeners off of all ckeditor instances, and screwed up ck's plugin system somehow.

I debugged in to ckeditor's source and saw the call this library does to `this.instance.destroy();` should be sufficient for the cleanup.   `destroy()` calls `this.removeAllListeners()`, removing its own listeners and not other ckeditor instance listeners:

<img width="429" alt="aaaa" src="https://user-images.githubusercontent.com/91095756/197587071-4c01594b-5239-40fb-b911-58e007d847f9.png">

We've been running with this change in production for a while now.

Thanks!